### PR TITLE
use pathlib to read json

### DIFF
--- a/energyMeter.py
+++ b/energyMeter.py
@@ -61,8 +61,7 @@ class energyMeter(object):
     def load_configs(self):
         config_file = Path(__file__).resolve().parent / "energyMeterConfig.json"
         try:
-            with open(config_file, "r", encoding="utf-8") as f:
-                self.config = json.loads(f.read())
+            self.config = json.loads(config_file.read_text())
         except (FileNotFoundError, json.JSONDecodeError) as e:
             print(f"Error loading configs from {config_file}: {e}")
             self.config = {

--- a/test_energyMeter.py
+++ b/test_energyMeter.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, mock_open, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 from energyMeter import energyMeter
 import json
 import psutil
@@ -11,7 +11,8 @@ class TestEnergyMeter(unittest.TestCase):
 
     def test_load_configs_success(self):
         mock_data = '{"processor": {"i7-8650U": 50, "DEFAULT": 100.0}, "ram": {"ddr4": 2}, "network": 1}'
-        with patch('builtins.open', mock_open(read_data=mock_data)):
+        with patch("pathlib.Path.read_text", autospec=True) as mock_read:
+            mock_read.side_effect = lambda self, *args, **kwargs: mock_data
             self.energy_meter.load_configs()
             self.assertEqual(self.energy_meter.config['processor']['i7-8650U'], 50)
 


### PR DESCRIPTION
This was used originally but as a quick fix to unittests, code was reverted back to use open() and context manager.